### PR TITLE
chore: print log in output channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### 0.0.3
 - Support highlight seleceted words
+
+### 0.0.4
+- Fix: Output logs in vscode channel

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,14 @@
 import * as vscode from "vscode";
 import { ActivityBar } from "./plugin/activityBar";
 import { Decorator } from "./plugin/decorator";
-import { LogLevel, logger } from "./logger";
+import { LogLevel, extensionOutputChannel, logger } from "./logger";
 import { registerVSCodeExtensionCommands } from "./commands";
 import { MarkerManager } from "./markerMngr";
 import { DelayRunner } from "./utils";
 
 export function activate(context: vscode.ExtensionContext) {
     logger.setLogLevel(LogLevel.DEBUG);
+    extensionOutputChannel.show();
 
     logger.info("extension activited!");
 
@@ -25,13 +26,29 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(
-        vscode.window.onDidChangeActiveTextEditor((editor) => mngr.reset()),
+        vscode.window.onDidChangeActiveTextEditor((editor) => {
+            const uri = editor?.document.uri;
+            // ignore the change of output channel
+            if (uri === undefined || !isFileURI(uri)) {
+                return;
+            }
+            if (!mngr.compareUriOrSet(uri)) {
+                logger.info(`editor changed, current=${uri.toString()}`);
+                mngr.reset(editor);
+            }
+        }),
 
         vscode.workspace.onDidChangeTextDocument((event) => {
+            // ignore the change of output channel
+            if (!isFileURI(event?.document.uri)) {
+                return;
+            }
+
             const editor = vscode.window.activeTextEditor;
             if (event.document.uri !== editor?.document.uri) {
                 return;
             }
+
             onDidChangeRunner.run();
         })
     );
@@ -39,3 +56,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export function deactivate() {}
+
+function isFileURI(uri: vscode.Uri | undefined): boolean {
+    if (uri === undefined) {
+        return false;
+    }
+    return uri.toString().startsWith("file://");
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,14 @@
+import * as vscode from "vscode";
+
 export enum LogLevel {
     ERROR,
     WARNING,
     INFO,
     DEBUG,
 }
+
+export const extensionOutputChannel =
+    vscode.window.createOutputChannel("Easy Marker");
 
 class Logger {
     private logLevel: LogLevel = LogLevel.INFO;
@@ -52,10 +57,10 @@ class Logger {
         msg = `[${level} - ${formatTime(new Date())}] ${msg}`;
 
         if (level === "ERROR") {
-            console.log("\x1b[31m%s\x1b[0m", msg);
-        } else {
-            console.log(msg);
+            msg = `\x1b[31m${msg}\x1b[0m`;
         }
+
+        extensionOutputChannel.appendLine(msg);
     }
 }
 

--- a/src/markerMngr.ts
+++ b/src/markerMngr.ts
@@ -24,6 +24,17 @@ export class MarkerManager extends PluginManager<IMarkerEventPayload> {
         Array<vscode.Range>
     >();
 
+    private currentOpenFileURI: string | undefined;
+
+    compareUriOrSet(uri: vscode.Uri): boolean {
+        const current = uri.toString();
+        if (this.currentOpenFileURI === current) {
+            return true;
+        }
+        this.currentOpenFileURI = current;
+        return false;
+    }
+
     add(marker: string) {
         if (this.highlights.size >= MAX_ITEMS) {
             vscode.window.showInformationMessage(
@@ -50,7 +61,7 @@ export class MarkerManager extends PluginManager<IMarkerEventPayload> {
         this.publish({ event: MarkerEventType.POST_REMOVE, marker });
     }
 
-    reset() {
+    reset(editor?: vscode.TextEditor) {
         if (!vscode.window.activeTextEditor) {
             return;
         }

--- a/src/plugin/activityBar.ts
+++ b/src/plugin/activityBar.ts
@@ -55,7 +55,7 @@ export class ActivityBar
                 this.highlights.delete(payload.marker as string);
                 break;
             default:
-                logger.warn(`ignore event, type=${payload.event}`);
+                logger.debug(`activity bar ignore event, type=${payload.event}`);
                 return;
         }
 

--- a/src/plugin/decorator.ts
+++ b/src/plugin/decorator.ts
@@ -17,6 +17,11 @@ interface RenderOption {
 
 const defaultRenderOptions: RenderOption[] = [
     {
+        name: "Dark Gray",
+        backgroundColor: "#34495E",
+        color: "#FFFFFF",
+    },
+    {
         name: "Red",
         backgroundColor: "#FF5733",
         color: "#FFFFFF",
@@ -61,11 +66,6 @@ const defaultRenderOptions: RenderOption[] = [
         backgroundColor: "#1ABC9C",
         color: "#FFFFFF",
     },
-    {
-        name: "Dark Gray",
-        backgroundColor: "#34495E",
-        color: "#FFFFFF",
-    },
 ];
 
 interface DecorationItem {
@@ -106,7 +106,7 @@ export class Decorator extends IPluginBase implements MarkerPlugin {
         const renderOp = nn.data;
         const marker = event.marker as string;
         this.decorateMarker(marker, renderOp);
-        logger.info(`decorate ${renderOp.name} for ${marker}`);
+        logger.info(`decorate [${renderOp.name}] for ${marker}`);
     }
 
     postRemove(event: IMarkerEventPayload): void {


### PR DESCRIPTION
**Changes:**
- Print logs in output channel "Easy Marker"

  ![image](https://github.com/Aleeeeexxxxx/marker/assets/167838389/1b7e0fd3-1ab2-4fad-9094-7a6dcb6a91ba)
- Adjusted the order of highlighting schemes, moving **Dark Gray** to the end since its effect is not prominent.
- Ignore the switching of the output channel in the event of **onDidChangeTextDocument** and **onDidChangeActiveTextEditor**.